### PR TITLE
decrease RGBLIGHT_LIMIT_VAL to suppress blinking

### DIFF
--- a/keyboards/re64/config.h
+++ b/keyboards/re64/config.h
@@ -76,7 +76,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_HUE_STEP 8
 //#    define RGBLIGHT_SAT_STEP 8
 //#    define RGBLIGHT_VAL_STEP 8
-    #define RGBLIGHT_LIMIT_VAL 150 /* The maximum brightness level */
+    #define RGBLIGHT_LIMIT_VAL 112 /* The maximum brightness level */
 //#    define RGBLIGHT_SLEEP  /* If defined, the RGB lighting will be switched off when the host goes to sleep */
 /*== all animations enable ==*/
 //#    define RGBLIGHT_ANIMATIONS


### PR DESCRIPTION
Re64でRGBLEDのSatulationを最大255まで上げてLEDを白色にした状態でValueを大きくすると 
電力不足のためか全LEDが点滅し始めます。

とりあえずValueの最大値を112くらいまで下げると同じ事をしても安定するようになりました。

最大値の変更をご検討ください。